### PR TITLE
Drops Fedora28 and CentOS6.x from our support OS

### DIFF
--- a/build.md
+++ b/build.md
@@ -17,13 +17,18 @@ next_string: Developer
 The build method for CHMPX Node.js addon library is explained below.
 
 ## 1. Install prerequisites before compiling
-- Debian / Ubuntu
+- For recent Debian-based Linux distributions users, follow the steps below:
 ```
 $ sudo aptitude update
 $ sudo aptitude git gcc g++ make gdb dh-make fakeroot dpkg-dev
 $ sudo aptitude install nodejs npm
 ```
-- Fedora / CentOS
+- For users who use supported Fedora other than latest version, follow the steps below:
+```
+$ sudo dnf install git autoconf automake gcc libstdc++-devel gcc-c++ make libtool
+$ sudo dnf install nodejs npm
+```
+- For other recent RPM-based Linux distributions users, follow the steps below:
 ```
 $ sudo yum install git autoconf automake gcc libstdc++-devel gcc-c++ make libtool
 $ sudo yum install nodejs npm

--- a/buildja.md
+++ b/buildja.md
@@ -17,13 +17,18 @@ next_string: Developer
 CHMPX Node.js アドオンライブラリをビルドする方法を説明します。
 
 ## 1. 事前環境
-- Debian / Ubuntu
+- 最近のDebianベースLinuxの利用者は、以下の手順に従ってください。
 ```
 $ sudo aptitude update
 $ sudo aptitude git gcc g++ make gdb dh-make fakeroot dpkg-dev
 $ sudo aptitude install nodejs npm
 ```
-- Fedora / CentOS
+- Fedoraの利用者は、以下の手順に従ってください。
+```
+$ sudo dnf install git autoconf automake gcc libstdc++-devel gcc-c++ make libtool
+$ sudo dnf install nodejs npm
+```
+- その他最近のRPMベースのLinuxの場合は、以下の手順に従ってください。
 ```
 $ sudo yum install git autoconf automake gcc libstdc++-devel gcc-c++ make libtool
 $ sudo yum install nodejs npm


### PR DESCRIPTION
## Relevant Issue (if applicable)
N/A

## Details
This PR removes unsupported OS descrptions from the manuals.