### PR TITLE
Updated some npm packages, added .auditignore, etc

### DIFF
--- a/.auditignore
+++ b/.auditignore
@@ -1,0 +1,1 @@
+https://npmjs.com/advisories/1673

--- a/.github/workflows/nodejs_helper.sh
+++ b/.github/workflows/nodejs_helper.sh
@@ -414,6 +414,7 @@ BUILD_SRCTOP="/tmp/${TMPSRCTOP}"
 #
 # Change current directory
 #
+echo "[INFO] ${PRGNAME} : Change current directory to ${BUILD_SRCTOP}"
 run_cmd cd ${BUILD_SRCTOP}
 
 #
@@ -425,6 +426,7 @@ run_cmd npm install
 #
 # Start build
 #
+echo "[INFO] ${PRGNAME} : Run npm run build."
 run_cmd npm run build
 
 #---------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
   },
   "dependencies": {
     "bindings": "^1.5.0",
-    "nan": "^2.14.2"
+    "nan": "^2.15.0"
   },
   "devDependencies": {
-    "chai": "^4.2.0",
-    "mocha": "^8.2.1",
+    "chai": "^4.3.4",
+    "mocha": "^9.1.0",
     "publish-please": "^5.5.2"
   },
   "scripts": {


### PR DESCRIPTION
### Relevant Issue (if applicable)
n/a

### Details
This package will be upgraded with new version of `chmpx`.
Relatedly, we have updated the versions of dependent packages(`nan`, `chai`, `mocha`).
And added comment in `nodejs_helper.sh` file.

#### NOTE
At this time, due to a vulnerability in `lodash`, the following `publish-please` is not yet supported.
https://npmjs.com/advisories/1673
Thus we add an `.auditignore` file for this problem.
Since `publish-please` is `devDependencies`, this fix allows you to ignore the above audit problem.