### PR TITLE
Updated support NodeJS version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        node-version: [14, 16, 18]
+        node-version: [18, 20]
 
     steps:
       #

--- a/.github/workflows/nodejstypevars.sh
+++ b/.github/workflows/nodejstypevars.sh
@@ -82,6 +82,12 @@ elif [ "${CI_NODEJS_MAJOR_VERSION}" = "18" ]; then
 	INSTALLER_BIN="apt-get"
 	INSTALL_QUIET_ARG="-qq"
 	IS_PUBLISHER=1
+
+elif [ "${CI_NODEJS_MAJOR_VERSION}" = "20" ]; then
+	INSTALL_PKG_LIST="git gcc g++ make chmpx-dev"
+	INSTALLER_BIN="apt-get"
+	INSTALL_QUIET_ARG="-qq"
+	IS_PUBLISHER=0
 fi
 
 #---------------------------------------------------------------


### PR DESCRIPTION
### Relevant Issues/Pull Requests (if applicable)
n/a

### Details
Changed NodeJS versions supported by Github Actions CI to 18 and 20.